### PR TITLE
Fix Transaction Timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -711,7 +711,7 @@ Get all transactions info
           "currency": "Ksh",
           "amount": 184.93,
           "type": "withdraw",
-          "timestamp": "2:26 AM"
+          "timestamp": "2024-05-30T14:55:45.000Z"
         }
       ]
     },
@@ -724,7 +724,7 @@ Get all transactions info
           "currency": "Ksh",
           "amount": 962.61,
           "type": "withdraw",
-          "timestamp": "8:16 PM"
+          "timestamp": "2024-05-30T14:55:45.000Z"
         }
       ]
     }
@@ -803,7 +803,7 @@ Transaction types in response body can either be: `sent|received|deposit|withdra
             "currency": "Ksh",
             "amount": 53.29,
             "type": "sent",
-            "timestamp": "3:38 PM"
+            "timestamp": "2024-05-28T14:10:45.000Z"
           }
         ]
       },
@@ -817,7 +817,7 @@ Transaction types in response body can either be: `sent|received|deposit|withdra
             "currency": "Ksh",
             "amount": 142.88,
             "type": "received",
-            "timestamp": "7:04 AM"
+            "timestamp": "2023-05-29T14:50:49.000Z"
           }
         ]
       }
@@ -1189,7 +1189,7 @@ Get all pending and approved transactions
         "amount": 535.91,
         "type": "withdraw",
         "status": "pending",
-        "timestamp": "6:35 PM"
+        "timestamp": "2023-09-02T18:35:45.000Z"
       },
       {
         "transaction_id": 28,
@@ -1199,7 +1199,7 @@ Get all pending and approved transactions
         "amount": 967.26,
         "type": "sent",
         "status": "pending",
-        "timestamp": "11:41 PM"
+        "timestamp": "2023-09-02T11:41:45.000Z"
       }
     ]
   }

--- a/src/controllers/walletController.js
+++ b/src/controllers/walletController.js
@@ -3,6 +3,7 @@ const userService = require("../services/userService");
 const UserNotFoundError = require("../errors/UserNotFoundError");
 const { formatTimestamp } = require("../utils");
 const PhoneNotRegisteredError = require("../errors/PhoneNotRegisteredError");
+const UnauthorizedOperationError = require("../errors/UnauthorizedOperationError");
 
 const getBalance = async (req, res, next) => {
   try {
@@ -35,18 +36,12 @@ const getBalance = async (req, res, next) => {
 const sendMoney = async (req, res, next) => {
   try {
     const { senderPhone, receiverPhone, amount } = req.body;
-
+    if(senderPhone === receiverPhone) {
+      throw new UnauthorizedOperationError("You cannot send money to yourself");
+    }
+    
     const sender = await userService.findByPhone(senderPhone);
-    if (!sender) {
-      throw new PhoneNotRegisteredError(senderPhone);
-    }
     const receiver = await userService.findByPhone(receiverPhone);
-    if (!receiver) {
-      throw new UserNotFoundError(
-        `Receiver with phone: ${receiverPhone} was not found`
-      );
-    }
-
     const transaction = await walletService.sendMoney(
       sender.id,
       receiver.id,

--- a/src/routes/statements.js
+++ b/src/routes/statements.js
@@ -1,10 +1,7 @@
 const express = require("express");
 const router = express.Router();
-const { body, query } = require("express-validator");
-const {
-  validateInput,
-  validateQueryParam,
-} = require("../middlewares/inputValidation");
+const { body } = require("express-validator");
+const { validateInput } = require("../middlewares/inputValidation");
 const { downloadStatement } = require("../controllers/statementController");
 
 router.post(
@@ -14,8 +11,8 @@ router.post(
     body("startDate").notEmpty().withMessage("Start date is required").isDate(),
     body("endDate").notEmpty().withMessage("End date is required").isDate(),
     body("transactionType")
-    .notEmpty()
-    .withMessage("Transaction type is required"),
+      .notEmpty()
+      .withMessage("Transaction type is required"),
     validateInput,
   ],
   downloadStatement

--- a/src/services/transactionsFormatterService.js
+++ b/src/services/transactionsFormatterService.js
@@ -20,7 +20,7 @@ const formatSentUserTransactions = (transactions) => {
             currency: transaction.currency,
             amount: transaction.amount,
             type: transaction.type,
-            timestamp: formatTimestamp(transaction.timestamp).split(", ")[1],
+            timestamp: transaction.timestamp,
           },
         ],
       });
@@ -32,7 +32,7 @@ const formatSentUserTransactions = (transactions) => {
         currency: transaction.currency,
         amount: transaction.amount,
         type: transaction.type,
-        timestamp: formatTimestamp(transaction.timestamp).split(", ")[1],
+        timestamp: transaction.timestamp
       });
     }
     return acc;
@@ -61,7 +61,7 @@ const formatReceivedUserTransactions = (transactions) => {
             currency: transaction.currency,
             amount: transaction.amount,
             type,
-            timestamp: formatTimestamp(transaction.timestamp).split(", ")[1],
+            timestamp: transaction.timestamp
           },
         ],
       });
@@ -73,7 +73,7 @@ const formatReceivedUserTransactions = (transactions) => {
         currency: transaction.currency,
         amount: transaction.amount,
         type,
-        timestamp: formatTimestamp(transaction.timestamp).split(", ")[1],
+        timestamp: transaction.timestamp
       });
     }
     return acc;
@@ -108,7 +108,7 @@ const formatAllTransactions = (transactions) => {
             currency: transaction.currency,
             amount: transaction.amount,
             type: transaction.type,
-            timestamp: formatTimestamp(transaction.timestamp).split(", ")[1],
+            timestamp: transaction.timestamp
           },
         ],
       });
@@ -120,7 +120,7 @@ const formatAllTransactions = (transactions) => {
         currency: transaction.currency,
         amount: transaction.amount,
         type: transaction.type,
-        timestamp: formatTimestamp(transaction.timestamp).split(", ")[1],
+        timestamp: transaction.timestamp
       });
     }
     return acc;
@@ -181,7 +181,7 @@ const formatAllUserTransactions = (transactions, user) => {
             currency: transaction.currency,
             amount: transaction.amount,
             type: getType(transaction), // for formatting received transactions
-            timestamp: formatTimestamp(transaction.timestamp).split(", ")[1],
+            timestamp: transaction.timestamp
           },
         ],
       });
@@ -193,7 +193,7 @@ const formatAllUserTransactions = (transactions, user) => {
         currency: transaction.currency,
         amount: transaction.amount,
         type: getType(transaction), // for formatting received transactions
-        timestamp: formatTimestamp(transaction.timestamp).split(", ")[1],
+        timestamp: transaction.timestamp
       });
     }
     return acc;
@@ -214,7 +214,7 @@ const formatAdminTransactions = (transactions) => {
       amount: transaction.amount,
       type: transaction.type,
       status: transaction.status,
-      timestamp: formatTimestamp(transaction.timestamp).split(", ")[1],
+      timestamp: transaction.timestamp
     };
     acc.push(response);
     return acc;


### PR DESCRIPTION
Fixed: You could send money to your own number
Fixed: Return UTC timestamp for transactions so that they can be formatted based on the timestamp of the client